### PR TITLE
Correção do Retorno da CEF

### DIFF
--- a/cnab240/104/retorno/detalhe_segmento_t.yml
+++ b/cnab240/104/retorno/detalhe_segmento_t.yml
@@ -1,13 +1,14 @@
 # Registro Detalhe - Segmento T (Obrigatório - Retorno)
 # Baseado na documentação da caixa cef
+# @link http://www.caixa.gov.br/downloads/cobranca-caixa-manuais/LEIAUTE_CNAB_240_SIGCB_COBRANCA_CAIXA.pdf
 
 uso_exclusivo_cef_01:
-  pos: [38, 46]
-  picture: 'X(9)'
+  pos: [30, 32]
+  picture: 'X(3)'
 
 nosso_numero:
-  pos: [47, 57]
-  picture: '9(11)'
+  pos: [42, 56]
+  picture: '9(15)'
 
 numero_documento:
   pos: [59, 69]

--- a/cnab240/104/retorno/detalhe_segmento_u.yml
+++ b/cnab240/104/retorno/detalhe_segmento_u.yml
@@ -2,10 +2,10 @@
 # Baseado na documentação da caixa cef
 
 data_debito_tarifa:
-  pos: [154, 161]
+  pos: [158, 165]
   picture: '9(8)'
   date_format: '%d%m%Y'
 
 uso_exclusivo_febraban_02:
-  pos: [162, 240]
+  pos: [234, 240]
   picture: '9(79)'

--- a/cnab240/104/retorno/detalhe_segmento_u.yml
+++ b/cnab240/104/retorno/detalhe_segmento_u.yml
@@ -8,4 +8,4 @@ data_debito_tarifa:
 
 uso_exclusivo_febraban_02:
   pos: [234, 240]
-  picture: '9(79)'
+  picture: '9(7)'


### PR DESCRIPTION
Fiz as correções para resolver o problema da leitura incorreta do nosso número da CEF testei com arquivos diferentes de retorno da CEF e o mesmo deu certo. Segui está documentação http://www.caixa.gov.br/downloads/cobranca-caixa-manuais/LEIAUTE_CNAB_240_SIGCB_COBRANCA_CAIXA.pdf

Espero ter ajudado.
Abraços.
