### PR TITLE
Correcao dv bb

### DIFF
--- a/cnab240/001/header_arquivo.yml
+++ b/cnab240/001/header_arquivo.yml
@@ -32,6 +32,10 @@ uso_exclusivo_bb_01:
   picture: 'X(2)'
   default: ''
 
+agencia_dv:
+  pos: [58, 58]
+  picture: 'X(1)'
+  
 conta:
   pos: [59, 70]
   picture: '9(12)'

--- a/cnab240/001/header_lote.yml
+++ b/cnab240/001/header_lote.yml
@@ -60,6 +60,10 @@ remessa_teste:
   picture: 'X(2)'
   default: ''
 
+agencia_dv:
+  pos: [59, 59]
+  picture: 'X(1)'
+  
 conta:
   pos: [60, 71]
   picture: '9(12)'

--- a/cnab240/001/remessa/detalhe_segmento_p.yml
+++ b/cnab240/001/remessa/detalhe_segmento_p.yml
@@ -1,10 +1,14 @@
+agencia_dv:
+  pos: [23,23]
+  picture: 'X(1)'
+  
 conta:
   pos: [24,35]
   picture: '9(12)'
 
 conta_dv:
   pos: [36,36]
-  picture: '9(1)'
+  picture: 'X(1)'
 
 agencia_mais_conta_dv:
   # Campo não tratado pelo Banco do Brasil. Informar 'branco' (espaço) OU zero

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "andersondanilo/cnab_yaml",
+    "name": "mensagemsei/cnab_yaml",
     "type": "library",
     "description": "Especificação do formato Cnab240 e Cnab400 traduzida para Yaml",
     "keywords": ["boleto", "remessa", "retorno", "cnab", "cnab240", "cnab400", "edi", "yaml"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
-{
-    "name": "mensagemsei/cnab_yaml",
+﻿{
+    "name": "andersondanilo/cnab_yaml",
     "type": "library",
     "description": "Especificação do formato Cnab240 e Cnab400 traduzida para Yaml",
     "keywords": ["boleto", "remessa", "retorno", "cnab", "cnab240", "cnab400", "edi", "yaml"],


### PR DESCRIPTION
Foi feita a correção do dígito verificador das agências e das contas nos arquivos yaml do Banco do Brasil.
Existem casos em que o dígito verificador pode ser "X", como estava validando somente números, então estava dando erro nesses casos. 
Conforme arquivo CNAB 240 do Banco do Brasil, nas normas Header de Arquivo (G009), Header de Lote (G009) e Segmento P (G009 e G011).